### PR TITLE
Track the reason behind invalid email for newsletter signup, allow different messages.

### DIFF
--- a/aldryn_jobs/templates/aldryn_jobs/newsletter_invalid_email.html
+++ b/aldryn_jobs/templates/aldryn_jobs/newsletter_invalid_email.html
@@ -11,16 +11,16 @@
     {% if resend_confirmation %}
         {% if condition == 'disabled' %}
             <p>
-                {% trans 'Seems that you did not wanted to get our newsleter anymore. If you change your mind - click on the link below.' %}
+                {% trans "You have been unsubscribed from the newsletter. If you'd like to change your mind please click the link below." %}
             </p>
         {% elif condiion == 'not_confirmed' %}
             <p>
-                {% trans 'If you want to resend confirmation e-mail - click on the link below.' %}
+                {% trans 'To resend the confirmation email please click the link below.' %}
             </p>
         {% endif %}
-        <p><a href="{{ resend_confirmation }}">{% trans 'Resend confirmation E-mail' context 'aldryn-jobs' %}</a></p>
+        <p><a href="{{ resend_confirmation }}">{% trans 'Resend confirmation e-mail' context 'aldryn-jobs' %}</a></p>
     {% else %}
-        <p>{% trans 'Please correct mistakes and try again.' context 'aldryn-jobs' %}</p>
+        <p>{% trans 'Please correct the errors and try again.' context 'aldryn-jobs' %}</p>
     {% endif %}
 </div>
 {% endblock %}

--- a/aldryn_jobs/views.py
+++ b/aldryn_jobs/views.py
@@ -151,11 +151,11 @@ class CheckResendSettingsMixin(object):
         condition = None
         if recipient_object.is_disabled:
             condition = 'disabled'
-            if ALLOW_RESEND_CONFIRMATION.get('disabled'):
+            if ALLOW_RESEND_CONFIRMATION.get('disabled', False):
                 allowed = True
         elif not recipient_object.is_verified:
             condition = 'not_confirmed'
-            if ALLOW_RESEND_CONFIRMATION.get('not_confirmed'):
+            if ALLOW_RESEND_CONFIRMATION.get('not_confirmed', False):
                 allowed = True
         return allowed, condition
 


### PR DESCRIPTION
TODO: make translations.

This changes allow to make different messages inside of a template depending on what was the reson for invalid email (for already registered emails).
