### PR TITLE
Fix issue with app config and namespaces, use namespace_url from aldryn-apphooks-config

### DIFF
--- a/aldryn_jobs/boilerplates/bootstrap3/templates/aldryn_jobs/jobs_detail.html
+++ b/aldryn_jobs/boilerplates/bootstrap3/templates/aldryn_jobs/jobs_detail.html
@@ -1,5 +1,5 @@
 {% extends "aldryn_jobs/base.html" %}
-{% load i18n cms_tags %}
+{% load i18n apphooks_config_tags cms_tags %}
 
 {% block content_jobs %}
 <div class="jobs-detail {% if user.is_staff and not object.get_active %}jobs-not-active{% endif %}">
@@ -16,6 +16,6 @@
 
 	{% include "aldryn_jobs/includes/jobs_application.html" %}
 
-	<p class="jobs-back"><a href="{% url 'aldryn_jobs:job-offer-list' %}">{% trans "Back" %}</a></p>
+	<p class="jobs-back"><a href="{% namespace_url 'job-offer-list' %}">{% trans "Back" %}</a></p>
 </div>
 {% endblock %}

--- a/aldryn_jobs/boilerplates/bootstrap3/templates/aldryn_jobs/plugins/newsletter_registration.html
+++ b/aldryn_jobs/boilerplates/bootstrap3/templates/aldryn_jobs/plugins/newsletter_registration.html
@@ -1,9 +1,10 @@
-{% load i18n %}
+{% load apphooks_config_tags i18n %}
 <div class="plugin plugin-job-newsletter-registration">
     <h2>{% trans 'Job Newsletter' context 'aldryn-jobs' %}</h2>
     <p>{% trans 'Enter your e-mail to receive a job newsletter' context 'aldryn-jobs' %}</p>
     <div class="jobs-newsletter-registration-form">
-        <form action="{% url 'aldryn_jobs:register_newsletter' %}" method="post">
+        {# FIXME: actually without apphook config this is not working. #}
+        <form action="{% namespace_url 'register_newsletter' %}" method="post">
             {% csrf_token %}
             {{ form.as_p }}
             <input type="submit" value="{% trans 'Subscribe' context 'aldryn-jobs' %}"/>

--- a/aldryn_jobs/boilerplates/legacy/templates/aldryn_jobs/jobs_detail.html
+++ b/aldryn_jobs/boilerplates/legacy/templates/aldryn_jobs/jobs_detail.html
@@ -1,5 +1,5 @@
 {% extends "aldryn_jobs/base.html" %}
-{% load i18n cms_tags %}
+{% load i18n apphooks_config_tags cms_tags  %}
 
 {% block content_jobs %}
 <div class="jobs-detail {% if user.is_staff and not object.get_active %}jobs-not-active{% endif %}">
@@ -16,6 +16,6 @@
 
 	{% include "aldryn_jobs/includes/jobs_application.html" %}
 
-	<p class="jobs-back"><a href="{% url 'aldryn_jobs:job-offer-list' %}">{% trans "Back" %}</a></p>
+	<p class="jobs-back"><a href="{% namespace_url 'job-offer-list' %}">{% trans "Back" %}</a></p>
 </div>
 {% endblock %}

--- a/aldryn_jobs/boilerplates/legacy/templates/aldryn_jobs/plugins/newsletter_registration.html
+++ b/aldryn_jobs/boilerplates/legacy/templates/aldryn_jobs/plugins/newsletter_registration.html
@@ -1,9 +1,10 @@
-{% load i18n %}
+{% load apphooks_config_tags i18n %}
 <div class="plugin plugin-job-newsletter-registration">
     <h2>{% trans 'Job Newsletter' context 'aldryn-jobs' %}</h2>
     <p>{% trans 'Enter your e-mail to receive a job newsletter' context 'aldryn-jobs' %}</p>
     <div class="jobs-newsletter-registration-form">
-        <form action="{% url 'aldryn_jobs:register_newsletter' %}" method="post">
+        {# FIXME: actually without apphook config this is not working. #}
+        <form action="{% namespace_url 'register_newsletter' %}" method="post">
             {% csrf_token %}
             {{ form.as_p }}
             <input type="submit" value="{% trans 'Subscribe' context 'aldryn-jobs' %}"/>


### PR DESCRIPTION
Changing url lookup with fixed namespace to namespace aware url lookup, to support multiple namespaces (which we try to do with aldryn-aphooks-config)

NOTE:  Apparently this is not sufficient for newsletter which does not contains app_config tracking anywhere...
