### PR TITLE
Fix language changer.

### DIFF
--- a/aldryn_jobs/views.py
+++ b/aldryn_jobs/views.py
@@ -83,6 +83,7 @@ class JobOfferDetail(AppConfigMixin, DetailView):
         self.request = request
         self.namespace, self.config = get_app_instance(request)
         self.object = self.get_object()
+        self.set_language_changer(self.object)
         return super(JobOfferDetail, self).dispatch(request, *args, **kwargs)
 
     def get_object(self, queryset=None):


### PR DESCRIPTION
Pretty simple fix. Step for setting language changer were missing which caused an issue with switching language on a detail page (using regular cms language changer and a cms toolbar language changer).

Code for this was there but wasn't used anywhere in the detail view.
