### PR TITLE
Fix django 1.7 cms 3.1 migration 0004 to use appropriate model.

### DIFF
--- a/aldryn_jobs/migrations/0004_data_create_default_namespace_20150210_1211.py
+++ b/aldryn_jobs/migrations/0004_data_create_default_namespace_20150210_1211.py
@@ -1,21 +1,37 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import models, migrations
-
+from django.db import models, migrations, transaction
+from django.db.models import get_model
+from django.db.utils import ProgrammingError
 
 def create_default_namespaces(apps, schema_editor):
-    from aldryn_jobs.models import JobListPlugin
+
     JobsConfig = apps.get_model('aldryn_jobs', 'JobsConfig')
     models = [apps.get_model('aldryn_jobs', 'JobCategory'),
               apps.get_model('aldryn_jobs', 'JobOffer'),
               apps.get_model('aldryn_jobs', 'JobApplication'),
-              JobListPlugin, ]
+              apps.get_model('aldryn_jobs', 'JobListPlugin'), ]
 
     ns, created = JobsConfig.objects.get_or_create(namespace='aldryn_jobs')
 
     for model in models:
-        for entry in model.objects.filter(app_config__isnull=True):
+        # if cms migrations migrated to latest and after that we will try to
+        # migrate this - we would get an exception because apps.get_model
+        # contains cms models at point of dependency migration
+        # so if that is the case - import latest model.
+        try:
+            # to avoid the following error:
+            #   django.db.utils.InternalError: current transaction is aborted,
+            #   commands ignored until end of transaction block
+            # we need to cleanup or avoid that by making them atomic.
+            with transaction.atomic():
+                model_objects = list(model.objects.filter(app_config__isnull=True))
+        except ProgrammingError:
+            new_model = get_model('aldryn_jobs.{0}'.format(model.__name__))
+            with transaction.atomic():
+                model_objects = new_model.objects.filter(app_config__isnull=True)
+        for entry in model_objects:
             entry.app_config = ns
             entry.save()
 


### PR DESCRIPTION
There was an issue because of migrations method "apps.get_model" picked up legacy db schema (cms 0003 which is pointed as a dependency) which caused a migration error if cms migrations were performed already. Though on a fresh database if all dependencies/packages are installed and configured it would work since migrations are applied in the right order.
