### PR TITLE
Fix issue if slug was not unique, validation error for not unique name and title

### DIFF
--- a/aldryn_jobs/admin.py
+++ b/aldryn_jobs/admin.py
@@ -140,7 +140,7 @@ class JobApplicationAdmin(VersionedPlaceholderAdminMixin, admin.ModelAdmin):
 class JobCategoryAdmin(VersionedPlaceholderAdminMixin,
                        AllTranslationsMixin, TranslatableAdmin):
     form = JobCategoryAdminForm
-    list_display = ['__str__', 'ordering']
+    list_display = ['__str__', 'ordering', 'app_config']
     list_editable = ['ordering']
     filter_horizontal = ['supervisors']
 

--- a/aldryn_jobs/forms.py
+++ b/aldryn_jobs/forms.py
@@ -127,9 +127,10 @@ class AutoSlugForm(TranslatableModelForm):
         language = self.get_language_code()
         app_config_filter = self.get_app_config_filter()
         # validate uniqueness
+        # translated accepts key word arguments not Q objects.
         found = self._meta.model.objects.language(language).filter(
             app_config_filter).translated(language,
-                                          Q(field_name=field)).count()
+                                          **{field_name: field}).count()
 
         if found > 0:
             self.append_to_errors(field_name, error_message)

--- a/aldryn_jobs/migrations/0001_initial.py
+++ b/aldryn_jobs/migrations/0001_initial.py
@@ -100,16 +100,6 @@ class Migration(migrations.Migration):
             bases=('cms.cmsplugin',),
         ),
         migrations.CreateModel(
-            name='JobNewsletterRegistrationPlugin',
-            fields=[
-                ('cmsplugin_ptr', models.OneToOneField(serialize=False, primary_key=True, auto_created=True, parent_link=True, to='cms.CMSPlugin')),
-            ],
-            options={
-                'abstract': False,
-            },
-            bases=('cms.cmsplugin',),
-        ),
-        migrations.CreateModel(
             name='JobOpening',
             fields=[
                 ('id', models.AutoField(serialize=False, primary_key=True, auto_created=True, verbose_name='ID')),
@@ -170,52 +160,13 @@ class Migration(migrations.Migration):
             },
             bases=(models.Model,),
         ),
-        migrations.CreateModel(
-            name='NewsletterSignup',
-            fields=[
-                ('id', models.AutoField(serialize=False, primary_key=True, auto_created=True, verbose_name='ID')),
-                ('recipient', models.EmailField(max_length=75, unique=True, verbose_name='recipient')),
-                ('default_language', models.CharField(max_length=32, choices=[('en', 'English'), ('de', 'German')], blank=True, default='', verbose_name='language')),
-                ('signup_date', models.DateTimeField(auto_now_add=True)),
-                ('is_verified', models.BooleanField(default=False)),
-                ('is_disabled', models.BooleanField(default=False)),
-                ('confirmation_key', models.CharField(max_length=40, unique=True)),
-                ('app_config', models.ForeignKey(null=True, to='aldryn_jobs.JobsConfig', verbose_name='app_config')),
-            ],
-            options={
-            },
-            bases=(models.Model,),
-        ),
-        migrations.CreateModel(
-            name='NewsletterSignupUser',
-            fields=[
-                ('id', models.AutoField(serialize=False, primary_key=True, auto_created=True, verbose_name='ID')),
-                ('signup', models.ForeignKey(related_name='related_user', to='aldryn_jobs.NewsletterSignup')),
-                ('user', models.ForeignKey(related_name='newsletter_signup', to=settings.AUTH_USER_MODEL)),
-            ],
-            options={
-            },
-            bases=(models.Model,),
-        ),
         migrations.AlterUniqueTogether(
             name='jobsconfig',
             unique_together=set([('type', 'namespace')]),
         ),
         migrations.AlterUniqueTogether(
             name='jobopeningtranslation',
-            unique_together=set([('language_code', 'master'), ('slug', 'language_code')]),
-        ),
-        migrations.AddField(
-            model_name='jobnewsletterregistrationplugin',
-            name='app_config',
-            field=models.ForeignKey(null=True, help_text='Select appropriate add-on configuration for this plugin.', to='aldryn_jobs.JobsConfig', verbose_name='app_config'),
-            preserve_default=True,
-        ),
-        migrations.AddField(
-            model_name='jobnewsletterregistrationplugin',
-            name='mail_to_group',
-            field=models.ManyToManyField(help_text='If user successfuly completed registration.<br/>Notification would be sent to users from selected groups<br/>Leave blank to disable notifications.<br/>', to='auth.Group', blank=True, verbose_name='Notification to'),
-            preserve_default=True,
+            unique_together=set([('language_code', 'master')]),
         ),
         migrations.AddField(
             model_name='joblistplugin',
@@ -231,7 +182,7 @@ class Migration(migrations.Migration):
         ),
         migrations.AlterUniqueTogether(
             name='jobcategorytranslation',
-            unique_together=set([('language_code', 'master'), ('slug', 'language_code')]),
+            unique_together=set([('language_code', 'master')]),
         ),
         migrations.AddField(
             model_name='jobcategory',

--- a/aldryn_jobs/models.py
+++ b/aldryn_jobs/models.py
@@ -139,8 +139,7 @@ class JobCategory(TranslatableModel):
         name=models.CharField(_('Name'), max_length=255),
         slug=models.SlugField(_('Slug'), max_length=255, blank=True,
             help_text=_('Auto-generated. Used in the URL. If changed, the URL'
-                        ' will change. Clean it to have it re-created.')),
-        meta={'unique_together': [['slug', 'language_code']]}
+                        ' will change. Clean it to have it re-created.'))
     )
 
     supervisors = models.ManyToManyField(
@@ -199,8 +198,7 @@ class JobOpening(TranslatableModel):
             help_text=_('Auto-generated. Used in the URL. If changed, the URL '
                         'will change. Clean it to have it re-created.')),
         lead_in=HTMLField(_('Lead in'), blank=True,
-            help_text=_('Will be displayed in lists')),
-        meta={'unique_together': [['slug', 'language_code']]}
+            help_text=_('Will be displayed in lists'))
     )
 
     content = PlaceholderField('Job Opening Content')

--- a/aldryn_jobs/tests/test_forms.py
+++ b/aldryn_jobs/tests/test_forms.py
@@ -1,5 +1,5 @@
 from ..cms_appconfig import JobsConfig
-from ..models import JobCategory, JobOpening
+from ..models import JobCategory
 from ..forms import JobCategoryAdminForm, JobOpeningAdminForm
 
 from .base import JobsBaseTestCase

--- a/aldryn_jobs/tests/test_forms.py
+++ b/aldryn_jobs/tests/test_forms.py
@@ -1,0 +1,206 @@
+from ..cms_appconfig import JobsConfig
+from ..models import JobCategory, JobOpening
+from ..forms import JobCategoryAdminForm, JobOpeningAdminForm
+
+from .base import JobsBaseTestCase
+
+
+class JobCategoryAdminFormTestCase(JobsBaseTestCase):
+
+    def test_form_not_valid_for_existing_name_in_same_app_config(self):
+        data = {
+            'app_config': self.app_config.pk,
+            'name': self.default_category_values['en']['name'],
+            'slug': 'default-category-different-slug',
+        }
+        form = JobCategoryAdminForm(data)
+        self.assertFalse(form.is_valid())
+
+        self.assertIn('name', form.errors.keys())
+        self.assertIn(
+            u'Category with that name already exists for selected app_config.',
+            form.errors['name'])
+
+    def test_form_valid_for_same_name_in_different_app_config(self):
+        other_config = JobsConfig.objects.create(namespace='other_config')
+        data = {
+            'app_config': other_config.pk,
+            'name': self.default_category_values['en']['name'],
+            'slug': 'default-category-different-slug',
+        }
+        form = JobCategoryAdminForm(data)
+        self.assertTrue(form.is_valid())
+        new_category = form.save()
+        self.assertEqual(new_category.name,
+                         data['name'])
+        self.assertEqual(new_category.slug,
+                         data['slug'])
+        self.assertEqual(new_category.app_config, other_config)
+
+    def test_form_not_valid_for_same_slug_in_same_app_config(self):
+        data = {
+            'name': 'different name',
+            'slug': self.default_category_values['en']['slug'],
+            'app_config': self.app_config.pk,
+        }
+        data.update(self.default_category_values['en'])
+        form = JobCategoryAdminForm(data)
+        self.assertFalse(form.is_valid())
+        self.assertIn('slug', form.errors.keys())
+
+    def test_form_valid_for_same_slug_in_different_app_config(self):
+        # depends on decision if we will remove uniqueness of slug per language
+        other_config = JobsConfig.objects.create(namespace='other_config')
+        data = {
+            'name': 'different name',
+            'slug': self.default_category_values['en']['slug'],
+            'app_config': self.app_config.pk,
+        }
+        data.update(self.default_category_values['en'])
+        form = JobCategoryAdminForm(data)
+        self.assertTrue(form.is_valid())
+        # test new category values
+        new_category = form.save()
+        self.assertEqual(new_category.name,
+                         data['name'])
+        self.assertEqual(new_category.slug,
+                         data['slug'])
+        self.assertEqual(new_category.app_config, other_config)
+
+    def test_form_is_valid_for_unique_name(self):
+        # form should allow unique names
+        data = {
+            'name': 'Unique name for category',
+            'app_config': self.app_config.pk
+        }
+        form = JobCategoryAdminForm(data)
+        self.assertTrue(form.is_valid())
+
+        # test new category values
+        new_category = form.save()
+        self.assertEqual(new_category.name,
+                         data['name'])
+        self.assertGreater(len(new_category.slug), 0)
+        self.assertEqual(new_category.app_config, self.app_config)
+
+    def test_form_is_valid_for_unique_slug(self):
+        # form should allow unique names
+        data = {
+            'name': 'Unique name for category with slug',
+            'slug': 'unique-name-for-category-with-slug',
+            'app_config': self.app_config.pk
+        }
+        form = JobCategoryAdminForm(data)
+        self.assertTrue(form.is_valid())
+        # test new category values
+        new_category = form.save()
+        self.assertEqual(new_category.name,
+                         data['name'])
+        self.assertGreater(len(new_category.slug), 0)
+        self.assertEqual(new_category.app_config, self.app_config)
+
+
+class JobOpeningAdminFormTestCase(JobsBaseTestCase):
+
+    def test_form_not_valid_for_existing_slug_in_same_category(self):
+        self.create_default_job_opening(translated=True)
+        # provide same data as for default opening
+        data = {
+            'category': self.default_category.pk,
+            'title': self.default_job_values['en']['title'],
+            'slug': self.default_job_values['en']['slug'],
+        }
+        form = JobOpeningAdminForm(data)
+        self.assertFalse(form.is_valid())
+
+        self.assertIn('title', form.errors.keys())
+        self.assertIn(
+            u'Opening with that title already exists for selected category.',
+            form.errors['title'])
+
+    def test_form_valid_for_same_name_in_different_category_app_config(self):
+        self.create_default_job_opening(translated=True)
+        # prepare category with other app config
+        other_config = JobsConfig.objects.create(namespace='other_config')
+        other_category = JobCategory.objects.create(
+            name='Other category', app_config=other_config)
+
+        data = {
+            'category': other_category.pk,
+            'title': self.default_job_values['en']['title'],
+            'slug': 'default-category-different-slug',
+        }
+        form = JobOpeningAdminForm(data)
+        self.assertTrue(form.is_valid())
+        new_opening = form.save()
+        self.assertEqual(new_opening.title,
+                         data['title'])
+        self.assertEqual(new_opening.slug,
+                         data['slug'])
+        self.assertEqual(new_opening.category, other_category)
+
+    def test_form_not_valid_for_same_slug_in_same_category(self):
+        self.create_default_job_opening(translated=True)
+        data = {
+            'title': 'different title',
+            'slug': self.default_job_values['en']['slug'],
+            'category': self.default_category.pk,
+        }
+        data.update(self.default_job_values['en'])
+        form = JobOpeningAdminForm(data)
+        self.assertFalse(form.is_valid())
+        self.assertIn('slug', form.errors.keys())
+
+    def test_form_valid_for_same_slug_in_different_category(self):
+        self.create_default_job_opening(translated=True)
+        # depends on decision if we will remove uniqueness of slug per language
+        other_config = JobsConfig.objects.create(namespace='other_config')
+        other_category = JobCategory.objects.create(
+            name='Other category', app_config=other_config)
+
+        data = {
+            'title': 'different title',
+            'slug': self.default_job_values['en']['slug'],
+            'category': self.default_category.pk,
+        }
+        data.update(self.default_job_values['en'])
+        form = JobOpeningAdminForm(data)
+        self.assertTrue(form.is_valid())
+        # test new category values
+        new_opening = form.save()
+        self.assertEqual(new_opening.title,
+                         data['title'])
+        self.assertEqual(new_opening.slug,
+                         data['slug'])
+        self.assertEqual(new_opening.category, other_category)
+
+    def test_form_is_valid_for_unique_name(self):
+        # form should allow unique names
+        data = {
+            'title': 'Unique title for opening',
+            'category': self.default_category.pk
+        }
+        form = JobOpeningAdminForm(data)
+        self.assertTrue(form.is_valid())
+        # test new category values
+        new_opening = form.save()
+        self.assertEqual(new_opening.title,
+                         data['title'])
+        self.assertGreater(len(new_opening.slug), 0)
+        self.assertEqual(new_opening.category, self.default_category)
+
+    def test_form_is_valid_for_unique_slug(self):
+        # form should allow unique names
+        data = {
+            'title': 'Unique title for opening with slug',
+            'slug': 'unique-title-for-opening-with-slug',
+            'category': self.default_category.pk
+        }
+        form = JobOpeningAdminForm(data)
+        self.assertTrue(form.is_valid())
+        # test new category values
+        new_opening = form.save()
+        self.assertEqual(new_opening.title,
+                         data['title'])
+        self.assertGreater(len(new_opening.slug), 0)
+        self.assertEqual(new_opening.category, self.default_category)

--- a/aldryn_jobs/tests/test_forms.py
+++ b/aldryn_jobs/tests/test_forms.py
@@ -54,7 +54,7 @@ class JobCategoryAdminFormTestCase(JobsBaseTestCase):
         data = {
             'name': 'different name',
             'slug': self.default_category_values['en']['slug'],
-            'app_config': self.app_config.pk,
+            'app_config': other_config.pk,
         }
         data.update(self.default_category_values['en'])
         form = JobCategoryAdminForm(data)
@@ -161,7 +161,7 @@ class JobOpeningAdminFormTestCase(JobsBaseTestCase):
         data = {
             'title': 'different title',
             'slug': self.default_job_values['en']['slug'],
-            'category': self.default_category.pk,
+            'category': other_category.pk,
         }
         data.update(self.default_job_values['en'])
         form = JobOpeningAdminForm(data)


### PR DESCRIPTION
There is an issue if slug is not unique, previous implementation used hvad attributes which are not present in parler.

Also PR introduces:
* Job opening title field validation and Job Category name validation per app_config
* Removes unique constraint of JobOpening and JobCategory (slug, language_code)
* test cases for admin form validation
* Removes newsletter tables from db (for 1.6) and from initial migration for 1.7


