### PR TITLE
Fix JobOpeningListView: respect apphooks, regression test cases.

### DIFF
--- a/aldryn_jobs/tests/base.py
+++ b/aldryn_jobs/tests/base.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 
 from datetime import datetime, timedelta
+from copy import deepcopy
 
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -247,3 +248,27 @@ class JobsBaseTestCase(TransactionTestCase):
                 new_val = value.format(replace_with)
             new_dict[key] = new_val
         return new_dict
+
+    def create_new_job_opening(self, data):
+        with override('en'):
+            job_opening = JobOpening.objects.create(**data)
+        return job_opening
+
+    def prepare_data(self, replace_with=1, category=None, update_date=False):
+        values = deepcopy(self.opening_values_raw['en'])
+        # if we need to change date to something in future
+        # we should do it before call to self.make_new_values
+        if update_date:
+            values.update(self.default_publication_start)
+        # make new values adds timedelta days=number which is passed as a
+        # second argument
+        values = self.make_new_values(values, replace_with)
+        # setup category
+        if category is None:
+            values['category'] = self.default_category
+        else:
+            values['category'] = category
+        # if date was not updated - use the default one
+        if not update_date:
+            values.update(self.default_publication_start)
+        return values

--- a/aldryn_jobs/tests/test_plugins.py
+++ b/aldryn_jobs/tests/test_plugins.py
@@ -1,9 +1,7 @@
-from copy import deepcopy
-
 from django.utils.translation import override
 from cms import api
 
-from ..models import JobOpening, JobCategory, JobsConfig
+from ..models import JobCategory, JobsConfig
 
 from .base import JobsBaseTestCase
 
@@ -179,30 +177,6 @@ class TestJobListPlugin(TestAppConfigPluginsMixin,
                 jobopenings)
             plugin.save()
         return plugin
-
-    def create_new_job_opening(self, data):
-        with override('en'):
-            job_opening = JobOpening.objects.create(**data)
-        return job_opening
-
-    def prepare_data(self, replace_with=1, category=None, update_date=False):
-        values = deepcopy(self.opening_values_raw['en'])
-        # if we need to change date to something in future
-        # we should do it before call to self.make_new_values
-        if update_date:
-            values.update(self.default_publication_start)
-        # make new values adds timedelta days=number which is passed as a
-        # second argument
-        values = self.make_new_values(values, replace_with)
-        # setup category
-        if category is None:
-            values['category'] = self.default_category
-        else:
-            values['category'] = category
-        # if date was not updated - use the default one
-        if not update_date:
-            values.update(self.default_publication_start)
-        return values
 
     def test_list_plugin_shows_selected_items(self):
         # since we setting up plugin in a setUp method with default

--- a/aldryn_jobs/views.py
+++ b/aldryn_jobs/views.py
@@ -24,12 +24,13 @@ class JobOpeningList(AppConfigMixin, ListView):
     def get_queryset(self):
         # have to be a method, so the language isn't cached
         language = get_language_from_request(self.request, check_path=True)
-        return (
-            JobOpening.objects.active()
-                              .language(language)
-                              .translated(language)
-                              .select_related('category')
-                              .order_by('category__id')
+        return (JobOpening.objects.filter(
+            category__app_config__namespace=self.namespace)
+            .active()
+            .language(language)
+            .translated(language)
+            .select_related('category')
+            .order_by('category__id')
         )
 
 

--- a/aldryn_jobs/views.py
+++ b/aldryn_jobs/views.py
@@ -44,8 +44,8 @@ class CategoryJobOpeningList(JobOpeningList):
         try:
             self.category = (
                 JobCategory.objects
-                           .language(language).active_translations(
-                                language, slug=category_slug)
+                           .language(language)
+                           .active_translations(language, slug=category_slug)
                            .namespace(self.namespace)
                            .get()
             )

--- a/test_settings.py
+++ b/test_settings.py
@@ -32,6 +32,7 @@ HELPER_SETTINGS = {
         'sortedm2m',
         'easy_thumbnails',
         'djangocms_text_ckeditor',
+        'adminsortable2',
     ],
     'THUMBNAIL_PROCESSORS': (
         'easy_thumbnails.processors.colorspace',


### PR DESCRIPTION
Filtering openings query set was missing namespace filters. That leaded to exposing openings from other app_config with broken links (`/en/`).

Also:
* small refactoring of test cases,
* adminsortable2 for test_settings.py