### PR TITLE
Add create_revision decorator so that job application initial revision is created

### DIFF
--- a/aldryn_jobs/cms_toolbar.py
+++ b/aldryn_jobs/cms_toolbar.py
@@ -74,6 +74,13 @@ class JobsToolbar(CMSToolbar):
 
     def populate(self):
         def can(actions, model):
+            try:
+                # Py2
+                basestring = basestring
+            except NameError:
+                # Py3
+                basestring = (str, bytes)
+
             if isinstance(actions, basestring):
                 actions = [actions]
             for action in actions:

--- a/aldryn_jobs/views.py
+++ b/aldryn_jobs/views.py
@@ -43,9 +43,13 @@ class CategoryJobOpeningList(JobOpeningList):
 
         category_slug = self.kwargs['category_slug']
         try:
-            self.category = JobCategory.objects.language(language).translated(
-                language, slug=category_slug
-            ).namespace(self.namespace).get()
+            self.category = (
+                JobCategory.objects
+                           .language(language)
+                           .translated(language, slug=category_slug)
+                           .namespace(self.namespace)
+                           .get()
+            )
         except JobCategory.DoesNotExist:
             raise Http404
 

--- a/aldryn_jobs/views.py
+++ b/aldryn_jobs/views.py
@@ -2,6 +2,9 @@
 
 from __future__ import unicode_literals
 
+import reversion
+
+from django.db import transaction
 from django.contrib import messages
 from django.http import Http404
 from django.shortcuts import redirect
@@ -127,6 +130,8 @@ class JobOpeningDetail(AppConfigMixin, DetailView):
         self.form = self.get_form(form_class)
         return super(JobOpeningDetail, self).get(*args, **kwargs)
 
+    @transaction.atomic
+    @reversion.create_revision()
     def post(self, *args, **kwargs):
         """Handles application for the job."""
         if not self.object.can_apply:


### PR DESCRIPTION
history will now have initial revision. Though there is no recover function for that model (we have to cover inlines in aldryn-reversions).