### PR TITLE
Decouple menu from app

### DIFF
--- a/aldryn_jobs/cms_app.py
+++ b/aldryn_jobs/cms_app.py
@@ -14,7 +14,6 @@ from .menu import JobCategoryMenu
 class JobsApp(CMSConfigApp):
     name = _('Jobs')
     urls = ['aldryn_jobs.urls']
-    menus = [JobCategoryMenu]
     app_config = JobsConfig
 
 apphook_pool.register(JobsApp)

--- a/aldryn_jobs/menu.py
+++ b/aldryn_jobs/menu.py
@@ -16,7 +16,7 @@ from .models import JobOpening
 
 class JobCategoryMenu(CMSAttachMenu):
 
-    name = _('Job Categories')
+    name = _("Job Categories Menu")
 
     def get_nodes(self, request):
         try:

--- a/docs/introduction/basic_usage.rst
+++ b/docs/introduction/basic_usage.rst
@@ -2,11 +2,17 @@
 Basic usage
 ###########
 
-Create a django CMS page to hook the Aldryn Jobs application into. In its *Advanced settings*,
-set its ``Application`` to *Jobs*, and use the provided, default *Jobs / aldryn_jobs* in
-``Application configurations`` before saving.
+Create a django CMS page to hook the Aldryn Jobs application into. In its
+*Advanced settings*, set its ``Application`` to *Jobs*, and use the provided,
+default *Jobs / aldryn_jobs* in ``Application configurations`` before saving.
 
-The page is now a landing page for job openings; it will be empty until you create some.
+The page is now a landing page for job openings; it will be empty until you
+create some.
 
-The behaviour of the Jobs system should be largely self-explanatory, but the :doc:`tutorial for
-users </user/index>` will guide you through some basic steps if necessary.
+Also in *Advanced settings*, you may choose to attach one of two menus as a
+sub-menu to the page in the site navigation: the ``Job Categories Menu`` or
+the ``Job Openings Menu``. No menu is attached automatically.
+
+The behaviour of the Jobs system should be largely self-explanatory, but the
+:doc:`tutorial for users </user/index>` will guide you through some basic steps
+if necessary.

--- a/docs/introduction/basic_usage.rst
+++ b/docs/introduction/basic_usage.rst
@@ -3,15 +3,15 @@ Basic usage
 ###########
 
 Create a django CMS page to hook the Aldryn Jobs application into. In its
-*Advanced settings*, set its ``Application`` to *Jobs*, and use the provided,
+*Advanced settings*, set its ``Application`` to *Jobs*, and use the provided
 default *Jobs / aldryn_jobs* in ``Application configurations`` before saving.
 
 The page is now a landing page for job openings; it will be empty until you
 create some.
 
 Also in *Advanced settings*, you may choose to attach one of two menus as a
-sub-menu to the page in the site navigation: the ``Job Categories Menu`` or
-the ``Job Openings Menu``. No menu is attached automatically.
+sub-menu to the page in the site navigation: the *Job Categories Menu* or
+the *Job Openings Menu*. No menu is attached automatically.
 
 The behaviour of the Jobs system should be largely self-explanatory, but the
 :doc:`tutorial for users </user/index>` will guide you through some basic steps


### PR DESCRIPTION
No longer automatically attach a menu with the app. Since we offer a choice, the user should attach the desired menu (if any).