### PR TITLE
Fix JobsConfig admin registration: register with VersionedPlaceholderAdminMixin

### DIFF
--- a/aldryn_jobs/admin.py
+++ b/aldryn_jobs/admin.py
@@ -211,7 +211,7 @@ class JobOpeningAdmin(AllTranslationsMixin,
     num_applications.admin_order_field = 'applications_count'
 
 
-class JobsConfigAdmin(BaseAppHookConfig):
+class JobsConfigAdmin(VersionedPlaceholderAdminMixin, BaseAppHookConfig):
     pass
 
 


### PR DESCRIPTION
This would allow job configs to be recovered after deletion.