### PR TITLE
Fix install docs, missing packages has been added into isntalled_apps.

### DIFF
--- a/docs/introduction/installation.rst
+++ b/docs/introduction/installation.rst
@@ -35,6 +35,8 @@ In your project's ``settings.py`` make sure you have all of::
     'aldryn_categories',
     'aldryn_jobs',
     'aldryn_translation_tools',
+    'adminsortable2',
+    'bootstrap3',
     'emailit',
     'parler',
     'sortedm2m',


### PR DESCRIPTION
Dependencies were adjusted, but docs were not.

Without this modules I was not able to use add-on (at least on `bootstrap3` boilerplate which probably uses `bootstrap3`, `adminsortable2` is a must have)