### PR TITLE
Fix 500 error if apphook is not reloaded, but there is a request already

### DIFF
--- a/aldryn_jobs/views.py
+++ b/aldryn_jobs/views.py
@@ -35,6 +35,10 @@ class JobsBaseMixin(object):
         Base queryset returns active JobOpenings with respect to language and
         namespace. selects related categories, no ordering.
         """
+        # if config is none - probably apphook relaod is in progress, or
+        # something is wrong, anyway do not fail with 500
+        if self.config is None:
+            return JobOpening.objects.none()
         return (
             JobOpening.objects.active()
                               .namespace(self.config.namespace)


### PR DESCRIPTION
It seems that if you are on a page and publish it auto reload is too quick and apphooks are not loaded properly yet, but we already rely on them while processing request to show job openings. that leads to 500 because we rely on namespace.