### PR TITLE
Update test settings to use features of djangocms-helper>=0.9.1, minor cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ env:
     - TOXENV=flake8
     - TOXENV=py34-dj17-cms31-sqlite-fe
     - TOXENV=py34-dj17-cms30-sqlite-fe
+    # FIXME: if py34 with dj16 will start to fail - delete them since dj16 supports up to py33
+    # https://docs.djangoproject.com/en/1.6/faq/install/#what-python-version-can-i-use-with-django
     - TOXENV=py34-dj16-cms31-sqlite-fe
     - TOXENV=py34-dj16-cms30-sqlite-fe
     - TOXENV=py33-dj17-cms31-sqlite-fe
@@ -24,15 +26,8 @@ env:
     - TOXENV=py27-dj17-cms30-sqlite-fe
     - TOXENV=py27-dj16-cms31-sqlite-fe
     - TOXENV=py27-dj16-cms30-sqlite-fe
-    - TOXENV=py26-dj17-cms31-sqlite-fe
-    - TOXENV=py26-dj17-cms30-sqlite-fe
     - TOXENV=py26-dj16-cms31-sqlite-fe
     - TOXENV=py26-dj16-cms30-sqlite-fe
-  # databases are not used yet, no appropriate setup...
-  #  - TOXENV=py27-dj17-cms30-mysql
-  #  - TOXENV=py27-dj17-cms30-postgres
-  #  - TOXENV=py27-dj17-cms31-mysql
-  #  - TOXENV=py27-dj17-cms31-postgres
 
 cache:
   directories:

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,4 @@
-djangocms-helper
+djangocms-helper>=0.9.1
 pysqlite
 pytz
 django-filer

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,5 +1,0 @@
-djangocms-helper>=0.9.1
-pysqlite
-pytz
-django-filer
-coverage

--- a/test_requirements/base.txt
+++ b/test_requirements/base.txt
@@ -1,6 +1,6 @@
 aldryn-apphook-reload>=0.2.2
 coverage>=3.7.1
 django-appconf
-djangocms-helper>=0.7
+djangocms-helper>=0.9.1
 django-filer
 flake8

--- a/test_settings.py
+++ b/test_settings.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+
 class DisableMigrations(dict):
 
     def __contains__(self, item):

--- a/test_settings.py
+++ b/test_settings.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
+from __future__ import unicode_literals
 
 class DisableMigrations(dict):
 
@@ -19,11 +19,9 @@ HELPER_SETTINGS = {
         # needed for tests, since we need to reload server after apphook has
         # been added to a page, otherwise we cannot get a correct url.
         'aldryn_apphook_reload',
-        'aldryn_boilerplates',
         'aldryn_categories',
         'aldryn_reversion',
         'aldryn_common',
-        'aldryn_jobs',
         'bootstrap3',
         'reversion',
         'appconf',
@@ -95,40 +93,13 @@ HELPER_SETTINGS = {
         'cms.middleware.page.CurrentPageMiddleware',
         'cms.middleware.toolbar.ToolbarMiddleware'
     ],
-    'STATICFILES_FINDERS': [
-        'django.contrib.staticfiles.finders.FileSystemFinder',
-        # important! place right before django.contrib.staticfiles.finders.AppDirectoriesFinder  # NOQA
-        'aldryn_boilerplates.staticfile_finders.AppDirectoriesFinder',
-        'django.contrib.staticfiles.finders.AppDirectoriesFinder',
-    ],
-    'TEMPLATE_CONTEXT_PROCESSORS': (
-        'django.contrib.auth.context_processors.auth',
-        'django.contrib.messages.context_processors.messages',
-        'django.core.context_processors.i18n',
-        'django.core.context_processors.debug',
-        'django.core.context_processors.request',
-        'django.core.context_processors.media',
-        'django.core.context_processors.csrf',
-        'django.core.context_processors.tz',
-        'sekizai.context_processors.sekizai',
-        'django.core.context_processors.static',
-        'cms.context_processors.cms_settings',
-        'aldryn_boilerplates.context_processors.boilerplate'
-    ),
-    'TEMPLATE_LOADERS': (
-        'django.template.loaders.filesystem.Loader',
-        # important! place right before django.template.loaders.app_directories.Loader  # NOQA
-        'aldryn_boilerplates.template_loaders.AppDirectoriesLoader',
-        'django.template.loaders.app_directories.Loader',
-        'django.template.loaders.eggs.Loader'
-    )
     # 'EMAIL_BACKEND': 'django.core.mail.backends.locmem.EmailBackend',
 }
 
 
 def run():
     from djangocms_helper import runner
-    runner.cms('aldryn_jobs')
+    runner.cms('aldryn_jobs', extra_args=['--boilerplate'])
 
 if __name__ == "__main__":
     run()

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,9 @@
 [tox]
-envlist = flake8, {py26,py27,py33,py34}-dj{16,17}-{sqlite,mysql,postgres}-cms{30,31}
-skip_missing_interpreters = True
+envlist =
+    flake8
+    py34-dj17-{sqlite,mysql,postgres}-cms{31,30}
+    py{33,27}-dj{17,16}-{sqlite,mysql,postgres}-cms{31,30}
+    py26-dj16-cms{31,30}
 
 [testenv]
 passenv =


### PR DESCRIPTION
* skip missing interpreters is removed, otherwise we wouldn't be sure what was tested.
* removed explicit boilerplate configuration for test cases, helper does that
* update djangocms-helper version dependency for test cases
* py26-dj17 not compatible
* fixme has been added to .travis.yml in case if tests start to fail for py34-dj16, until then we have unofficial support =)
* minor cleanup