### PR TITLE
Use aldryn-translation-tools for slug generation

### DIFF
--- a/aldryn_jobs/forms.py
+++ b/aldryn_jobs/forms.py
@@ -9,14 +9,11 @@ from django import forms
 from django.db.models import Q
 from django.conf import settings
 from django.core.exceptions import (
-    ObjectDoesNotExist,
     ValidationError,
     ImproperlyConfigured,
 )
 from django.core.urlresolvers import reverse
-from django.template.defaultfilters import slugify
-from django.utils.safestring import mark_safe
-from django.utils.translation import gettext as _, get_language, ugettext
+from django.utils.translation import ugettext
 
 from aldryn_apphooks_config.utils import setup_config
 from app_data import AppDataForm
@@ -26,7 +23,6 @@ from distutils.version import LooseVersion
 from emailit.api import send_mail
 from multiupload.fields import MultiFileField
 from parler.forms import TranslatableModelForm
-from unidecode import unidecode
 
 
 from .models import (

--- a/aldryn_jobs/tests/test_forms.py
+++ b/aldryn_jobs/tests/test_forms.py
@@ -49,20 +49,6 @@ class JobCategoryAdminFormTestCase(JobsBaseTestCase):
         self.assertIn('name', form.errors.keys())
         self.assertIn('app_config', form.errors.keys())
 
-    def test_form_not_valid_for_existing_name_in_same_app_config(self):
-        data = {
-            'app_config': self.app_config.pk,
-            'name': self.default_category_values['en']['name'],
-            'slug': 'default-category-different-slug',
-        }
-        form = JobCategoryAdminForm(data)
-        self.assertFalse(form.is_valid())
-
-        self.assertIn('name', form.errors.keys())
-        self.assertIn(
-            u'Category with that name already exists for selected app_config.',
-            form.errors['name'])
-
     def test_form_valid_for_same_name_in_different_app_config(self):
         other_config = JobsConfig.objects.create(namespace='other_config')
         data = {
@@ -78,17 +64,6 @@ class JobCategoryAdminFormTestCase(JobsBaseTestCase):
         self.assertEqual(new_category.slug,
                          data['slug'])
         self.assertEqual(new_category.app_config, other_config)
-
-    def test_form_not_valid_for_same_slug_in_same_app_config(self):
-        data = {
-            'name': 'different name',
-            'slug': self.default_category_values['en']['slug'],
-            'app_config': self.app_config.pk,
-        }
-        data.update(self.default_category_values['en'])
-        form = JobCategoryAdminForm(data)
-        self.assertFalse(form.is_valid())
-        self.assertIn('slug', form.errors.keys())
 
     def test_form_valid_for_same_slug_in_different_app_config(self):
         # depends on decision if we will remove uniqueness of slug per language
@@ -156,22 +131,6 @@ class JobOpeningAdminFormTestCase(JobsBaseTestCase):
         self.assertFalse(form.is_valid())
         self.assertIn('category', form.errors.keys())
 
-    def test_form_not_valid_for_existing_slug_in_same_category(self):
-        self.create_default_job_opening(translated=True)
-        # provide same data as for default opening
-        data = {
-            'category': self.default_category.pk,
-            'title': self.default_job_values['en']['title'],
-            'slug': self.default_job_values['en']['slug'],
-        }
-        form = JobOpeningAdminForm(data)
-        self.assertFalse(form.is_valid())
-
-        self.assertIn('title', form.errors.keys())
-        self.assertIn(
-            u'Opening with that title already exists for selected category.',
-            form.errors['title'])
-
     def test_form_valid_for_same_name_in_different_category_app_config(self):
         self.create_default_job_opening(translated=True)
         # prepare category with other app config
@@ -192,18 +151,6 @@ class JobOpeningAdminFormTestCase(JobsBaseTestCase):
         self.assertEqual(new_opening.slug,
                          data['slug'])
         self.assertEqual(new_opening.category, other_category)
-
-    def test_form_not_valid_for_same_slug_in_same_category(self):
-        self.create_default_job_opening(translated=True)
-        data = {
-            'title': 'different title',
-            'slug': self.default_job_values['en']['slug'],
-            'category': self.default_category.pk,
-        }
-        data.update(self.default_job_values['en'])
-        form = JobOpeningAdminForm(data)
-        self.assertFalse(form.is_valid())
-        self.assertIn('slug', form.errors.keys())
 
     def test_form_valid_for_same_slug_in_different_category(self):
         self.create_default_job_opening(translated=True)

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ REQUIREMENTS = [
     'aldryn-boilerplates',
     'aldryn-common>=0.0.4',
     'aldryn-reversion>=0.1.0',
-    'aldryn-translation-tools>=0.0.7',
+    'aldryn-translation-tools>=0.2.1',
     # Although we don't actually yet use Aldryn Categories, it has been added
     # because of a migration dependency that sneaked in somehow. In any case we
     # plan to adopt Aldryn Categories for this project in a release in


### PR DESCRIPTION
Tests should be adjusted, since ``aldryn-tranalstaion-tools`` would generate "slug-1" if "slug" is already taken, which differs from previous implementaion