### PR TITLE
Update test config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,20 +17,20 @@ env:
     #   FE strategy: only test on Django/CMS combinations, but place tests on
     #                different Python ENVs if possible.
     - TOXENV=flake8
-    - TOXENV=py34-dj18-sqlite-cms32-fe
+    - TOXENV=py34-dj18-sqlite-cms32
     - TOXENV=py34-dj18-sqlite-cms31-fe
     - TOXENV=py27-dj18-sqlite-cms32
     - TOXENV=py27-dj18-sqlite-cms31
     - TOXENV=py34-dj17-sqlite-cms32
     - TOXENV=py34-dj17-sqlite-cms31
     - TOXENV=py34-dj17-sqlite-cms30
-    - TOXENV=py27-dj17-sqlite-cms32-fe
+    - TOXENV=py27-dj17-sqlite-cms32
     - TOXENV=py27-dj17-sqlite-cms31-fe
     - TOXENV=py27-dj17-sqlite-cms30-fe
     - TOXENV=py27-dj16-sqlite-cms32
     - TOXENV=py27-dj16-sqlite-cms31
     - TOXENV=py27-dj16-sqlite-cms30
-    - TOXENV=py26-dj16-sqlite-cms32-fe
+    - TOXENV=py26-dj16-sqlite-cms32
     - TOXENV=py26-dj16-sqlite-cms31-fe
     - TOXENV=py26-dj16-sqlite-cms30-fe
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,16 +12,13 @@ env:
     - secure: eegYV50fPm2nRBcjn8fniKUmiH7bnMvxNTT4mV0BQuYahKbqdCia2qpzKFzgBO187CtvI3vnmJ7sxyZtKmlNy/lBYco5tTahfeQnOCjOvk81oMnpnlIao/PLJ8soR32lCVcnkb/kaQ/7IrMszQ9BfV6XLIIb+7Job7TZxlM9USkHewhJT/7P4h9fNhuLLCD1rZpnCPXGFAW+asowY0o/G607K3zxLmCyRb52Lsu7KijW1S2C9mIbSw/wnkgbFDhzT51CN3iHNutBPfWy7l8WLrCvEp8oPxoNrC/6WY6vSJXNLZ3loERbXxawupObn3QvbVQxRVtCaTTIVaBtwO4fe5q0KYeDY2SMq3keH0x7WHMfRmRrkLk8YcuwghA7cw6otx4hxROODCoSidTMNLlx2jOojMAhENhKcEZphqOoFEToJ+pBYDtIbZbdTht45kqziZ+3LGoX4kvL3dvTK8Dai28RbIZKsLD6e75JRA07gFzKqExF3iyHri+kpoMGxydUl1FdWafgnZb7Bf0BVSsP1E70Hwmstf+9GXv77F4ggGW9xtICkAIkMbdLkkCDzSWbp7yKpxNE9nLqV9ZNgFNef6zXrYkH9REFspI5PJaxnfs4fW8hidtL4gKjLPppfPRyWVw7iChzVQ73ezXe3ryGeTe88WECUs8aVpSFn9DwbdY=
   matrix:
     # Matrix-size reduction strategies:
-    #   PY strategy is to not test 3.3 at all.
-    #   DB strategy is to only test all db backends on the newest and oldest Django ENV that they're supported.
-    #   FE strategy is to only test on Django/CMS combinations, but place tests on different Python ENVs if possible.
+    #   PY strategy: do not test 3.3 at all.
+    #   DB strategy: only with SQLite as we're not using any raw queries.
+    #   FE strategy: only test on Django/CMS combinations, but place tests on
+    #                different Python ENVs if possible.
     - TOXENV=flake8
     - TOXENV=py34-dj18-sqlite-cms32-fe
     - TOXENV=py34-dj18-sqlite-cms31-fe
-    - TOXENV=py34-dj18-mysql-cms32
-    - TOXENV=py34-dj18-mysql-cms31
-    - TOXENV=py34-dj18-postgres-cms32
-    - TOXENV=py34-dj18-postgres-cms31
     - TOXENV=py27-dj18-sqlite-cms32
     - TOXENV=py27-dj18-sqlite-cms31
     - TOXENV=py34-dj17-sqlite-cms32
@@ -30,21 +27,12 @@ env:
     - TOXENV=py27-dj17-sqlite-cms32-fe
     - TOXENV=py27-dj17-sqlite-cms31-fe
     - TOXENV=py27-dj17-sqlite-cms30-fe
-    - TOXENV=py27-dj17-mysql-cms32
-    - TOXENV=py27-dj17-mysql-cms31
-    - TOXENV=py27-dj17-mysql-cms30
     - TOXENV=py27-dj16-sqlite-cms32
     - TOXENV=py27-dj16-sqlite-cms31
     - TOXENV=py27-dj16-sqlite-cms30
     - TOXENV=py26-dj16-sqlite-cms32-fe
     - TOXENV=py26-dj16-sqlite-cms31-fe
     - TOXENV=py26-dj16-sqlite-cms30-fe
-    - TOXENV=py26-dj16-postgres-cms32
-    - TOXENV=py26-dj16-postgres-cms31
-    - TOXENV=py26-dj16-postgres-cms30
-    - TOXENV=py26-dj16-oldmysql-cms32
-    - TOXENV=py26-dj16-oldmysql-cms31
-    - TOXENV=py26-dj16-oldmysql-cms30
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,25 +11,40 @@ env:
     # encrypted Code Climate token
     - secure: eegYV50fPm2nRBcjn8fniKUmiH7bnMvxNTT4mV0BQuYahKbqdCia2qpzKFzgBO187CtvI3vnmJ7sxyZtKmlNy/lBYco5tTahfeQnOCjOvk81oMnpnlIao/PLJ8soR32lCVcnkb/kaQ/7IrMszQ9BfV6XLIIb+7Job7TZxlM9USkHewhJT/7P4h9fNhuLLCD1rZpnCPXGFAW+asowY0o/G607K3zxLmCyRb52Lsu7KijW1S2C9mIbSw/wnkgbFDhzT51CN3iHNutBPfWy7l8WLrCvEp8oPxoNrC/6WY6vSJXNLZ3loERbXxawupObn3QvbVQxRVtCaTTIVaBtwO4fe5q0KYeDY2SMq3keH0x7WHMfRmRrkLk8YcuwghA7cw6otx4hxROODCoSidTMNLlx2jOojMAhENhKcEZphqOoFEToJ+pBYDtIbZbdTht45kqziZ+3LGoX4kvL3dvTK8Dai28RbIZKsLD6e75JRA07gFzKqExF3iyHri+kpoMGxydUl1FdWafgnZb7Bf0BVSsP1E70Hwmstf+9GXv77F4ggGW9xtICkAIkMbdLkkCDzSWbp7yKpxNE9nLqV9ZNgFNef6zXrYkH9REFspI5PJaxnfs4fW8hidtL4gKjLPppfPRyWVw7iChzVQ73ezXe3ryGeTe88WECUs8aVpSFn9DwbdY=
   matrix:
+    # Matrix-size reduction strategies:
+    #   PY strategy is to not test 3.3 at all.
+    #   DB strategy is to only test all db backends on the newest and oldest Django ENV that they're supported.
+    #   FE strategy is to only test on Django/CMS combinations, but place tests on different Python ENVs if possible.
     - TOXENV=flake8
-    - TOXENV=py34-dj18-sqlite-cms31
+    - TOXENV=py34-dj18-sqlite-cms32-fe
+    - TOXENV=py34-dj18-sqlite-cms31-fe
+    - TOXENV=py34-dj18-mysql-cms32
+    - TOXENV=py34-dj18-mysql-cms31
+    - TOXENV=py34-dj18-postgres-cms32
+    - TOXENV=py34-dj18-postgres-cms31
+    - TOXENV=py27-dj18-sqlite-cms32
     - TOXENV=py27-dj18-sqlite-cms31
-    - TOXENV=py34-dj17-cms31-sqlite-fe
-    - TOXENV=py34-dj17-cms30-sqlite-fe
-    # FIXME: if py34 with dj16 will start to fail - delete them since dj16 supports up to py33
-    # https://docs.djangoproject.com/en/1.6/faq/install/#what-python-version-can-i-use-with-django
-    - TOXENV=py34-dj16-cms31-sqlite-fe
-    - TOXENV=py34-dj16-cms30-sqlite-fe
-    - TOXENV=py33-dj17-cms31-sqlite-fe
-    - TOXENV=py33-dj17-cms30-sqlite-fe
-    - TOXENV=py33-dj16-cms31-sqlite-fe
-    - TOXENV=py33-dj16-cms30-sqlite-fe
-    - TOXENV=py27-dj17-cms31-sqlite-fe
-    - TOXENV=py27-dj17-cms30-sqlite-fe
-    - TOXENV=py27-dj16-cms31-sqlite-fe
-    - TOXENV=py27-dj16-cms30-sqlite-fe
-    - TOXENV=py26-dj16-cms31-sqlite-fe
-    - TOXENV=py26-dj16-cms30-sqlite-fe
+    - TOXENV=py34-dj17-sqlite-cms32
+    - TOXENV=py34-dj17-sqlite-cms31
+    - TOXENV=py34-dj17-sqlite-cms30
+    - TOXENV=py27-dj17-sqlite-cms32-fe
+    - TOXENV=py27-dj17-sqlite-cms31-fe
+    - TOXENV=py27-dj17-sqlite-cms30-fe
+    - TOXENV=py27-dj17-mysql-cms32
+    - TOXENV=py27-dj17-mysql-cms31
+    - TOXENV=py27-dj17-mysql-cms30
+    - TOXENV=py27-dj16-sqlite-cms32
+    - TOXENV=py27-dj16-sqlite-cms31
+    - TOXENV=py27-dj16-sqlite-cms30
+    - TOXENV=py26-dj16-sqlite-cms32-fe
+    - TOXENV=py26-dj16-sqlite-cms31-fe
+    - TOXENV=py26-dj16-sqlite-cms30-fe
+    - TOXENV=py26-dj16-postgres-cms32
+    - TOXENV=py26-dj16-postgres-cms31
+    - TOXENV=py26-dj16-postgres-cms30
+    - TOXENV=py26-dj16-oldmysql-cms32
+    - TOXENV=py26-dj16-oldmysql-cms31
+    - TOXENV=py26-dj16-oldmysql-cms30
 
 cache:
   directories:

--- a/test
+++ b/test
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-djangocms-helper aldryn_jobs --cms test --extra-settings=test_settings $@
+djangocms-helper aldryn_jobs --cms --boilerplate test --extra-settings=test_settings $@

--- a/test_requirements/base.txt
+++ b/test_requirements/base.txt
@@ -2,5 +2,5 @@ aldryn-apphook-reload>=0.2.3
 coverage>=3.7.1
 django-appconf
 djangocms-helper>=0.9.1
-django-filer
+django-filer==1.0.6
 flake8

--- a/test_requirements/django_1.6.txt
+++ b/test_requirements/django_1.6.txt
@@ -1,4 +1,9 @@
 django>=1.6,<1.7
 django-reversion<1.8.3
 South
+
+# NOTE: These are for Filer
+django-mptt>=0.6,<0.8
+django-polymorphic>=0.5.4
+
 -r base.txt

--- a/test_requirements/django_1.7.txt
+++ b/test_requirements/django_1.7.txt
@@ -1,4 +1,8 @@
 django>=1.7.4,<1.8
 django-reversion>=1.8.7,<1.9
 
+# NOTE: These are for Filer
+django-mptt>=0.6,<0.8
+django-polymorphic>=0.5.6
+
 -r base.txt

--- a/test_requirements/django_1.8.txt
+++ b/test_requirements/django_1.8.txt
@@ -1,4 +1,8 @@
 django>=1.8,<1.9
 django-reversion>=1.9.3
 
+# NOTE: These are for Filer
+django-mptt>=0.7
+django-polymorphic>=0.7
+
 -r base.txt

--- a/test_settings.py
+++ b/test_settings.py
@@ -2,6 +2,11 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+from distutils.version import LooseVersion
+from cms import __version__ as cms_string_version
+
+cms_version = LooseVersion(cms_string_version)
+
 
 class DisableMigrations(dict):
 
@@ -81,7 +86,6 @@ HELPER_SETTINGS = {
     # add aldryn_apphook_reload so that pages would be restored on apphook
     # reload.
     'MIDDLEWARE_CLASSES': [
-        'aldryn_apphook_reload.middleware.ApphookReloadMiddleware',
         'django.middleware.http.ConditionalGetMiddleware',
         'django.contrib.sessions.middleware.SessionMiddleware',
         'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -89,6 +93,8 @@ HELPER_SETTINGS = {
         'django.middleware.csrf.CsrfViewMiddleware',
         'django.middleware.locale.LocaleMiddleware',
         'django.middleware.common.CommonMiddleware',
+        # NOTE: This will actually be removed below in CMS<3.2 installs.
+        'cms.middleware.utils.ApphookReloadMiddleware',
         'cms.middleware.language.LanguageCookieMiddleware',
         'cms.middleware.user.CurrentUserMiddleware',
         'cms.middleware.page.CurrentPageMiddleware',
@@ -96,6 +102,15 @@ HELPER_SETTINGS = {
     ],
     # 'EMAIL_BACKEND': 'django.core.mail.backends.locmem.EmailBackend',
 }
+
+
+# If using CMS 3.2+, use the CMS middleware for ApphookReloading, otherwise,
+# use aldryn_apphook_reload's.
+if cms_version < LooseVersion('3.2.0'):
+    HELPER_SETTINGS['MIDDLEWARE_CLASSES'].remove(
+        'cms.middleware.utils.ApphookReloadMiddleware')
+    HELPER_SETTINGS['MIDDLEWARE_CLASSES'].insert(
+        0, 'aldryn_apphook_reload.middleware.ApphookReloadMiddleware')
 
 
 def run():

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,10 @@
 [tox]
 envlist =
     flake8
-    py34-dj18-{sqlite,mysql,postgres}-cms31
-    py34-dj17-{sqlite,mysql,postgres}-cms{31,30}
-    py{33,27}-dj{18,17}-{sqlite,mysql,postgres}-cms31
-    py{33,27}-dj{17,16}-{sqlite,mysql,postgres}-cms{31,30}
-    py26-dj16-cms{31,30}
+    py{34,33,27}-dj18-{sqlite,mysql,postgres}-cms{32,31}
+    py{34,33,27}-dj17-{sqlite,mysql,postgres}-cms{32,31,30}
+    py{33,27}-dj16-{sqlite,mysql,postgres}-cms{32,31,30}
+    py{26}-dj16-{sqlite,oldmysql,postgres}-cms{32,31,30}
 
 [testenv]
 passenv =
@@ -34,10 +33,14 @@ deps =
     dj16: -rtest_requirements/django_1.6.txt
     dj17: -rtest_requirements/django_1.7.txt
     dj18: -rtest_requirements/django_1.8.txt
-    mysql: MySQL-python
+    # Does not support Python 2.6 or lower
+    mysql: mysqlclient
+    # Does not support Python 3+
+    oldmysql: MySQL-python
     postgres: psycopg2
     cms30: django-cms<3.1
     cms31: django-cms<3.2
+    cms32: django-cms<3.3
 basepython =
     py26: python2.6
     py27: python2.7


### PR DESCRIPTION
Updates test configuration to test against CMS 3.2 and latest versions of Django Filer and its dependencies. Also, rationalizes test env matrix and fixes mysql test envs.

NOTE: Disables FE tests for CMS 3.2 until these tests can be updated.