### PR TITLE
integration tests 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,22 +17,22 @@ env:
     #   FE strategy: only test on Django/CMS combinations, but place tests on
     #                different Python ENVs if possible.
     - TOXENV=flake8
-    - TOXENV=py34-dj18-sqlite-cms32
-    - TOXENV=py34-dj18-sqlite-cms31-fe
+    - TOXENV=py34-dj18-sqlite-cms32-fe
+    - TOXENV=py34-dj18-sqlite-cms31
     - TOXENV=py27-dj18-sqlite-cms32
     - TOXENV=py27-dj18-sqlite-cms31
     - TOXENV=py34-dj17-sqlite-cms32
     - TOXENV=py34-dj17-sqlite-cms31
     - TOXENV=py34-dj17-sqlite-cms30
-    - TOXENV=py27-dj17-sqlite-cms32
-    - TOXENV=py27-dj17-sqlite-cms31-fe
-    - TOXENV=py27-dj17-sqlite-cms30-fe
+    - TOXENV=py27-dj17-sqlite-cms32-fe
+    - TOXENV=py27-dj17-sqlite-cms31
+    - TOXENV=py27-dj17-sqlite-cms30
     - TOXENV=py27-dj16-sqlite-cms32
     - TOXENV=py27-dj16-sqlite-cms31
     - TOXENV=py27-dj16-sqlite-cms30
-    - TOXENV=py26-dj16-sqlite-cms32
-    - TOXENV=py26-dj16-sqlite-cms31-fe
-    - TOXENV=py26-dj16-sqlite-cms30-fe
+    - TOXENV=py26-dj16-sqlite-cms32-fe
+    - TOXENV=py26-dj16-sqlite-cms31
+    - TOXENV=py26-dj16-sqlite-cms30
 
 cache:
   directories:

--- a/aldryn_jobs/tests/frontend/base.conf.js
+++ b/aldryn_jobs/tests/frontend/base.conf.js
@@ -20,5 +20,5 @@ module.exports = {
         ].join(' ');
     },
 
-    sauceLabsBrowsers: b2s({ browsers: ['chrome 42'] })
+    sauceLabsBrowsers: b2s({ browsers: ['chrome 47'] })
 };

--- a/aldryn_jobs/tests/frontend/integration/pages/page.jobs.crud.js
+++ b/aldryn_jobs/tests/frontend/integration/pages/page.jobs.crud.js
@@ -35,8 +35,10 @@ var jobsPage = {
     slugErrorNotification: element(by.css('.errors.slug')),
     saveButton: element(by.css('.submit-row [name="_save"]')),
     editPageLink: element(by.css('.col-preview [href*="preview/"]')),
+    sideFrameClose: element(by.css('.cms-sideframe-close')),
 
     // adding new apphook config
+    breadcrumbs: element(by.css('.breadcrumbs')),
     breadcrumbsLinks: element.all(by.css('.breadcrumbs a')),
     jobsAddConfigsLink: element(by.css('.model-jobsconfig .addlink')),
     namespaceInput: element(by.id('id_namespace')),
@@ -51,6 +53,7 @@ var jobsPage = {
 
     // adding new job opening
     addJobOpeningsButton: element(by.css('.model-jobopening .addlink')),
+    editJobOpeningsButton: element(by.css('.model-jobopening .changelink')),
     categorySelect: element(by.id('id_category')),
     categoryOption: element(by.css('#id_category > option:nth-child(2)')),
     startDateLinks: element.all(by.css(
@@ -59,6 +62,7 @@ var jobsPage = {
         '#id_publication_start_1 + .datetimeshortcuts > a')),
     endDateInput: element(by.id('id_publication_end_0')),
     endTimeInput: element(by.id('id_publication_end_1')),
+    editJobOpeningLinksTable: element(by.css('.results')),
     editJobOpeningLinks: element.all(by.css(
         '.results th > [href*="/aldryn_jobs/jobopening/"]')),
 

--- a/aldryn_jobs/tests/frontend/integration/pages/page.jobs.crud.js
+++ b/aldryn_jobs/tests/frontend/integration/pages/page.jobs.crud.js
@@ -15,26 +15,26 @@ var jobsPage = {
     iframeWaitTime: 15000,
 
     // log in
-    editModeLink: element(by.css('.inner a[href="/?edit"]')),
-    usernameInput: element(by.id('id_cms-username')),
-    passwordInput: element(by.id('id_cms-password')),
-    loginButton: element(by.css('.cms_form-login input[type="submit"]')),
-    userMenus: element.all(by.css('.cms_toolbar-item-navigation > li > a')),
-    testLink: element(by.css('.selected a')),
+    usernameInput: element(by.id('id_username')),
+    passwordInput: element(by.id('id_password')),
+    loginButton: element(by.css('input[type="submit"]')),
+    userMenus: element.all(by.css('.cms-toolbar-item-navigation > li > a')),
+    testLink: element(by.cssContainingText('a', 'Test')),
 
     // adding new page
+    modalCloseButton: element(by.css('.cms-modal-close')),
     userMenuDropdown: element(by.css(
-        '.cms_toolbar-item-navigation-hover')),
+        '.cms-toolbar-item-navigation-hover')),
     administrationOptions: element.all(by.css(
-        '.cms_toolbar-item-navigation a[href="/en/admin/"]')),
-    sideMenuIframe: element(by.css('.cms_sideframe-frame iframe')),
+        '.cms-toolbar-item-navigation a[href="/en/admin/"]')),
+    sideMenuIframe: element(by.css('.cms-sideframe-frame iframe')),
     pagesLink: element(by.css('.model-page > th > a')),
     addConfigsButton: element(by.css('.object-tools .addlink')),
     addPageLink: element(by.css('.sitemap-noentry .addlink')),
     titleInput: element(by.id('id_title')),
     slugErrorNotification: element(by.css('.errors.slug')),
     saveButton: element(by.css('.submit-row [name="_save"]')),
-    editPageLink: element(by.css('.col1 [href*="preview/"]')),
+    editPageLink: element(by.css('.col-preview [href*="preview/"]')),
 
     // adding new apphook config
     breadcrumbsLinks: element.all(by.css('.breadcrumbs a')),
@@ -65,13 +65,13 @@ var jobsPage = {
     // adding jobs block to the page
     aldrynJobsBlock: element(by.css('.app-jobs')),
     advancedSettingsOption: element(by.css(
-        '.cms_toolbar-item-navigation [href*="advanced-settings"]')),
-    modalIframe: element(by.css('.cms_modal-frame iframe')),
+        '.cms-toolbar-item-navigation [href*="advanced-settings"]')),
+    modalIframe: element(by.css('.cms-modal-frame iframe')),
     applicationSelect: element(by.id('application_urls')),
     jobsOption: element(by.css('option[value="JobsApp"]')),
-    saveModalButton: element(by.css('.cms_modal-buttons .cms_btn-action')),
-    jobsOpeningLink: element(by.css('.jobs-title > a')),
-    jobTitle: element(by.css('.jobs-detail h2 > div')),
+    saveModalButton: element(by.css('.cms-modal-buttons .cms-btn-action')),
+    jobsOpeningLink: element(by.css('.aldryn-jobs-article > h3 > a')),
+    jobTitle: element(by.css('.aldryn-jobs-detail h3 > div')),
 
     // deleting job opening
     deleteButton: element(by.css('.deletelink-box a')),
@@ -94,7 +94,8 @@ var jobsPage = {
             return jobsPage.passwordInput.sendKeys(
                 credentials.password);
         }).then(function () {
-            jobsPage.loginButton.click();
+            return jobsPage.loginButton.click();
+        }).then(function () {
 
             // wait for user menu to appear
             browser.wait(browser.isElementPresent(

--- a/aldryn_jobs/tests/frontend/integration/pages/page.jobs.crud.js
+++ b/aldryn_jobs/tests/frontend/integration/pages/page.jobs.crud.js
@@ -100,6 +100,9 @@ var jobsPage = {
         }).then(function () {
             return jobsPage.loginButton.click();
         }).then(function () {
+            // this is required for django1.6, because it doesn't redirect
+            // correctly from admin
+            browser.get(jobsPage.site);
 
             // wait for user menu to appear
             browser.wait(browser.isElementPresent(

--- a/aldryn_jobs/tests/frontend/integration/specs/spec.jobs.crud.js
+++ b/aldryn_jobs/tests/frontend/integration/specs/spec.jobs.crud.js
@@ -117,10 +117,15 @@ describe('Aldryn Jobs tests: ', function () {
                     '.cms-sideframe-frame iframe')));
             }
         }).then(function () {
-            cmsProtractorHelper.waitFor(jobsPage.breadcrumbsLinks.first());
+            browser.sleep(1000);
 
-            // click the Home link in breadcrumbs
-            jobsPage.breadcrumbsLinks.first().click();
+            jobsPage.breadcrumbs.isPresent().then(function (present) {
+                if (present) {
+                    // click the Home link in breadcrumbs
+                    cmsProtractorHelper.waitFor(jobsPage.breadcrumbsLinks.first());
+                    jobsPage.breadcrumbsLinks.first().click();
+                }
+            });
 
             cmsProtractorHelper.waitFor(jobsPage.jobsAddConfigsLink);
 
@@ -304,13 +309,14 @@ describe('Aldryn Jobs tests: ', function () {
             .frame(browser.findElement(By.css('.cms-sideframe-frame iframe')));
 
         cmsProtractorHelper.waitFor(jobsPage.editJobOpeningsButton);
-        jobsPage.editJobOpeningsButton.click();
-
-        // wait for edit job opening link to appear
-        cmsProtractorHelper.waitFor(jobsPage.editJobOpeningLinksTable);
-
-        // validate edit job opening links texts to delete proper job opening
-        jobsPage.editJobOpeningLinks.first().getText().then(function (text) {
+        browser.sleep(100);
+        jobsPage.editJobOpeningsButton.click().then(function () {
+            // wait for edit job opening link to appear
+            return cmsProtractorHelper.waitFor(jobsPage.editJobOpeningLinksTable);
+        }).then(function () {
+            // validate edit job opening links texts to delete proper job opening
+            return jobsPage.editJobOpeningLinks.first().getText();
+        }).then(function (text) {
             // wait till horizontal scrollbar will disappear and
             // editJobOpeningLinks will become clickable
             browser.sleep(1500);

--- a/aldryn_jobs/tests/frontend/integration/specs/spec.jobs.crud.js
+++ b/aldryn_jobs/tests/frontend/integration/specs/spec.jobs.crud.js
@@ -24,6 +24,7 @@ describe('Aldryn Jobs tests: ', function () {
             if (present === true) {
                 // go to the main page
                 browser.get(jobsPage.site + '?edit');
+                browser.sleep(1000);
                 cmsProtractorHelper.waitForDisplayed(jobsPage.usernameInput);
             }
 
@@ -41,6 +42,8 @@ describe('Aldryn Jobs tests: ', function () {
         });
 
         cmsProtractorHelper.waitForDisplayed(jobsPage.userMenus.first());
+        // have to wait till animation finished
+        browser.sleep(300);
         // click the example.com link in the top menu
         jobsPage.userMenus.first().click().then(function () {
             // wait for top menu dropdown options to appear

--- a/aldryn_jobs/tests/frontend/integration/specs/spec.jobs.crud.js
+++ b/aldryn_jobs/tests/frontend/integration/specs/spec.jobs.crud.js
@@ -24,13 +24,8 @@ describe('Aldryn Jobs tests: ', function () {
             if (present === true) {
                 // go to the main page
                 browser.get(jobsPage.site + '?edit');
-            } else {
-                // click edit mode link
-                jobsPage.editModeLink.click();
+                cmsProtractorHelper.waitForDisplayed(jobsPage.usernameInput);
             }
-
-            // wait for username input to appear
-            cmsProtractorHelper.waitFor(jobsPage.usernameInput);
 
             // login to the site
             jobsPage.cmsLogin();
@@ -38,10 +33,18 @@ describe('Aldryn Jobs tests: ', function () {
     });
 
     it('creates a new test page', function () {
+        // close the wizard if necessary
+        jobsPage.modalCloseButton.isDisplayed().then(function (displayed) {
+            if (displayed) {
+                jobsPage.modalCloseButton.click();
+            }
+        });
+
+        cmsProtractorHelper.waitForDisplayed(jobsPage.userMenus.first());
         // click the example.com link in the top menu
         jobsPage.userMenus.first().click().then(function () {
             // wait for top menu dropdown options to appear
-            cmsProtractorHelper.waitFor(jobsPage.userMenuDropdown);
+            cmsProtractorHelper.waitForDisplayed(jobsPage.userMenuDropdown);
 
             return jobsPage.administrationOptions.first().click();
         }).then(function () {
@@ -50,7 +53,7 @@ describe('Aldryn Jobs tests: ', function () {
 
             // switch to sidebar menu iframe
             browser.switchTo().frame(browser.findElement(
-                By.css('.cms_sideframe-frame iframe')));
+                By.css('.cms-sideframe-frame iframe')));
 
             cmsProtractorHelper.waitFor(jobsPage.pagesLink);
 
@@ -108,7 +111,7 @@ describe('Aldryn Jobs tests: ', function () {
 
                 // switch to sidebar menu iframe
                 return browser.switchTo().frame(browser.findElement(By.css(
-                    '.cms_sideframe-frame iframe')));
+                    '.cms-sideframe-frame iframe')));
             }
         }).then(function () {
             cmsProtractorHelper.waitFor(jobsPage.breadcrumbsLinks.first());
@@ -234,7 +237,7 @@ describe('Aldryn Jobs tests: ', function () {
 
                     // switch to modal iframe
                     browser.switchTo().frame(browser.findElement(By.css(
-                        '.cms_modal-frame iframe')));
+                        '.cms-modal-frame iframe')));
 
                     // set Jobs Application
                     cmsProtractorHelper.selectOption(jobsPage.applicationSelect,
@@ -274,7 +277,7 @@ describe('Aldryn Jobs tests: ', function () {
 
         // switch to sidebar menu iframe
         browser.switchTo()
-            .frame(browser.findElement(By.css('.cms_sideframe-frame iframe')));
+            .frame(browser.findElement(By.css('.cms-sideframe-frame iframe')));
 
         // wait for edit job opening link to appear
         cmsProtractorHelper.waitFor(jobsPage.editJobOpeningLinks.first());

--- a/aldryn_jobs/tests/frontend/integration/specs/spec.jobs.crud.js
+++ b/aldryn_jobs/tests/frontend/integration/specs/spec.jobs.crud.js
@@ -265,6 +265,16 @@ describe('Aldryn Jobs tests: ', function () {
             // wait for link to appear in aldryn jobs block
             cmsProtractorHelper.waitFor(jobsPage.jobsOpeningLink);
 
+            // wait till animation of sideframe opening finishes
+            browser.sleep(300);
+
+            // close sideframe (it covers the link)
+            cmsProtractorHelper.waitFor(jobsPage.sideFrameClose);
+            jobsPage.sideFrameClose.click();
+
+            // wait till animation finishes
+            browser.sleep(300);
+
             jobsPage.jobsOpeningLink.click();
 
             cmsProtractorHelper.waitFor(jobsPage.jobTitle);
@@ -275,15 +285,29 @@ describe('Aldryn Jobs tests: ', function () {
     });
 
     it('deletes job opening', function () {
-        // wait for modal iframe to appear
-        cmsProtractorHelper.waitFor(jobsPage.sideMenuIframe);
+        cmsProtractorHelper.waitForDisplayed(jobsPage.userMenus.first());
+        // have to wait till animation finished
+        browser.sleep(300);
+        // click the example.com link in the top menu
+        jobsPage.userMenus.first().click().then(function () {
+            // wait for top menu dropdown options to appear
+            cmsProtractorHelper.waitForDisplayed(jobsPage.userMenuDropdown);
+
+            return jobsPage.administrationOptions.first().click();
+        }).then(function () {
+            // wait for modal iframe to appear
+            cmsProtractorHelper.waitFor(jobsPage.sideMenuIframe);
+        });
 
         // switch to sidebar menu iframe
         browser.switchTo()
             .frame(browser.findElement(By.css('.cms-sideframe-frame iframe')));
 
+        cmsProtractorHelper.waitFor(jobsPage.editJobOpeningsButton);
+        jobsPage.editJobOpeningsButton.click();
+
         // wait for edit job opening link to appear
-        cmsProtractorHelper.waitFor(jobsPage.editJobOpeningLinks.first());
+        cmsProtractorHelper.waitFor(jobsPage.editJobOpeningLinksTable);
 
         // validate edit job opening links texts to delete proper job opening
         jobsPage.editJobOpeningLinks.first().getText().then(function (text) {

--- a/aldryn_jobs/tests/frontend/protractor.conf.js
+++ b/aldryn_jobs/tests/frontend/protractor.conf.js
@@ -20,8 +20,7 @@ var config = {
 
     // Capabilities to be passed to the webdriver instance
     capabilities: {
-        'browserName': 'phantomjs',
-        'phantomjs.binary.path': require('phantomjs').path
+        'browserName': 'chrome'
     },
 
     onPrepare: function () {

--- a/aldryn_jobs/tests/frontend/protractor.conf.js
+++ b/aldryn_jobs/tests/frontend/protractor.conf.js
@@ -36,7 +36,8 @@ var config = {
 
     jasmineNodeOpts: {
         showColors: true,
-        defaultTimeoutInterval: 240000
+        defaultTimeoutInterval: 240000,
+        realtimeFailure: true
     }
 
 };

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
         "node": "0.9.0"
     },
     "devDependencies": {
-        "browserslist-saucelabs": "^0.1.4",
+        "browserslist-saucelabs": "^0.2.5",
         "cms-protractor-helper": "^1.0.0",
         "gulp": "3.9.0",
         "gulp-jscs": "1.6.0",

--- a/test_settings.py
+++ b/test_settings.py
@@ -19,6 +19,7 @@ class DisableMigrations(dict):
 gettext = lambda s: s
 
 HELPER_SETTINGS = {
+    'CMS_PERMISSION': True,
     'TIME_ZONE': 'Europe/Zurich',
     'INSTALLED_APPS': [
         'aldryn_apphooks_config',

--- a/test_settings.py
+++ b/test_settings.py
@@ -82,7 +82,7 @@ HELPER_SETTINGS = {
             },
         ],
     },
-    'ALDRYN_BOILERPLATE_NAME': 'legacy',
+    'ALDRYN_BOILERPLATE_NAME': 'bootstrap3',
     # add aldryn_apphook_reload so that pages would be restored on apphook
     # reload.
     'MIDDLEWARE_CLASSES': [


### PR DESCRIPTION
* changes tests so they work with 3.2
    - sideframe is now covering most of the view so it has to be opened/closed
    - admin behaviour changed slightly
    - selectors changed
    - added additional safety waits
* change the default local runner from `phantomjs` to `chrome` because literally nothing works in phantom (and http://www.protractortest.org/#/browser-support)
* changed the ALDRYN_BOILERPLATE_NAME to be bootstrap3, doesn't make much sense to test legacy anymore
* add CMS_PERMISSION setting, because apparently there is a regression in the 3.2 that hides the Pages menu item if it's not set