### PR TITLE
Force the process to exit with error code if couldn't create the tunnel

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -53,7 +53,7 @@ gulp.task('lint', function () {
         .pipe(jshint.reporter('jshint-stylish'));
 });
 
-// #########################################################
+// #############################################################################
 // TESTS
 gulp.task('tests', ['tests:unit', 'tests:lint', 'tests:integration']);
 gulp.task('tests:lint', ['lint']);
@@ -79,8 +79,9 @@ gulp.task('tests:sauce:start', function (done) {
     tunnel.start(function (isCreated) {
         isTunnelCreated = isCreated;
         if (!isCreated) {
-            console.log('Failed to create Sauce tunnel, skipping tests');
-            done();
+            console.log('Failed to create Sauce tunnel, returning error code');
+            // Force the process to exit with error code if couldn't create the tunnel
+            process.exit(1);
             return false;
         }
         console.log('Connected to Sauce Labs.');
@@ -102,7 +103,8 @@ gulp.task('tests:sauce:end', function (done) {
 gulp.task('tests:webdriver', webdriverUpdate);
 gulp.task('tests:integration', ['tests:webdriver', 'tests:sauce:start'], function () {
     if (process.env.CI && !isTunnelCreated) {
-        // Skipping tests if couldn't create the tunnel.
+        // Force the process to exit with error code if couldn't create the tunnel
+        process.exit(1);
         return false;
     }
     return gulp.src([PROJECT_PATH.tests + '/integration/specs/*.js'])


### PR DESCRIPTION
**This pull request updates _gulpfile.js_ to force the process to exit with error code if couldn't create the Sauce Labs tunnel**