### PR TITLE
Bump django-sortedm2m version. Set up toxworkdir to homedir.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ REQUIREMENTS = [
     # the very near future.
     'aldryn-categories',
     'django-multiupload>=0.3',
-    'django-sortedm2m',
+    'django-sortedm2m>=1.2.2',
     'django-admin-sortable2>=0.5.2',
     'unidecode',
     'lxml',

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,5 @@
 [tox]
+toxworkdir = {homedir}/.toxenvs/aldryn-jobs
 envlist =
     flake8
     py{34,33,27}-dj{18,19}-{sqlite,mysql,postgres}-cms32


### PR DESCRIPTION
Setting up ``toxworkdir`` to homedir. this will add some preformance for test env setup.