### PR TITLE
Re-pin html5lib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ REQUIREMENTS = [
     'lxml',
     'pytz',
     'cssutils',
-    'html5lib<0.9999',
+    'html5lib<=0.9999999',
 ]
 
 py26 = sys.version_info >= (2, 6, 5) and sys.version_info < (2, 7, 0)


### PR DESCRIPTION
django-cms 3.3.x requires html5lib>=9999999.

@czpython 