### PR TITLE
fixes/django cms33 compat

### DIFF
--- a/aldryn_jobs/cms_wizards.py
+++ b/aldryn_jobs/cms_wizards.py
@@ -138,9 +138,23 @@ class CreateJobOpeningForm(BaseFormMixin, TranslatableModelForm):
         # If 'content' field has value, create a TextPlugin with same and add
         # it to the PlaceholderField
         content = clean_html(self.cleaned_data.get('content', ''), False)
-        content_plugin = get_cms_setting('WIZARD_CONTENT_PLUGIN')
+
+        try:
+            # CMS >= 3.3.x
+            content_plugin = get_cms_setting('PAGE_WIZARD_CONTENT_PLUGIN')
+        except KeyError:
+            # CMS <= 3.2.x
+            content_plugin = get_cms_setting('WIZARD_CONTENT_PLUGIN')
+
+        try:
+            # CMS >= 3.3.x
+            content_field = get_cms_setting('PAGE_WIZARD_CONTENT_PLUGIN_BODY')
+        except KeyError:
+            # CMS <= 3.2.x
+            content_field = get_cms_setting('WIZARD_CONTENT_PLUGIN_BODY')
+
         if content and permissions.has_plugin_permission(
-                self.user, 'TextPlugin', 'add'):
+                self.user, content_plugin, 'add'):
 
             # If the job_opening has not been saved, then there will be no
             # Placeholder set-up for this question yet, so, ensure we have saved
@@ -153,7 +167,7 @@ class CreateJobOpeningForm(BaseFormMixin, TranslatableModelForm):
                     'placeholder': job_opening.content,
                     'plugin_type': content_plugin,
                     'language': self.language_code,
-                    get_cms_setting('WIZARD_CONTENT_PLUGIN_BODY'): content,
+                    content_field: content,
                 }
                 add_plugin(**plugin_kwargs)
 

--- a/aldryn_jobs/tests/test_wizards.py
+++ b/aldryn_jobs/tests/test_wizards.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+import sys
+
+from distutils.version import LooseVersion
+
+import cms
+
+from aldryn_jobs.cms_wizards import CreateJobOpeningForm
+
+from .base import JobsBaseTestCase
+
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
+
+# The CMS wizard system was introduced in 3.2.0
+CMS_3_2 = LooseVersion(cms.__version__) >= LooseVersion('3.2.0')
+
+
+@unittest.skipUnless(CMS_3_2, "No wizard support in CMS < 3.2")
+class TestJobsWizard(JobsBaseTestCase):
+
+    def setUp(self):
+        super(TestJobsWizard, self).setUp()
+        self.client.login(
+            username=self.super_user.username,
+            password=self.super_user_password,
+        )
+
+    def test_job_opening_wizard(self):
+        data = {
+            'title': 'Ninja coder',
+            'lead_in': 'Ninja coder wanted',
+            'content': '<p>Needs skills in Python/Django.</p>',
+            'is_active': True,
+            'category': self.default_category.pk,
+        }
+        form = CreateJobOpeningForm(
+            data=data,
+            wizard_language='en',
+            wizard_user=self.super_user,
+        )
+        self.assertTrue(form.is_valid())
+        question = form.save()
+
+        url = question.get_absolute_url('en')
+        response = self.client.get(url)
+        self.assertContains(response, 'Ninja coder', status_code=200)
+        self.assertContains(response, '<p>Needs skills in Python/Django.</p>', status_code=200)

--- a/aldryn_jobs/tests/test_wizards.py
+++ b/aldryn_jobs/tests/test_wizards.py
@@ -48,4 +48,8 @@ class TestJobsWizard(JobsBaseTestCase):
         url = question.get_absolute_url('en')
         response = self.client.get(url)
         self.assertContains(response, 'Ninja coder', status_code=200)
-        self.assertContains(response, '<p>Needs skills in Python/Django.</p>', status_code=200)
+        self.assertContains(
+            response,
+            '<p>Needs skills in Python/Django.</p>',
+            status_code=200,
+        )

--- a/aldryn_jobs/tests/test_wizards.py
+++ b/aldryn_jobs/tests/test_wizards.py
@@ -5,8 +5,6 @@ from distutils.version import LooseVersion
 
 import cms
 
-from aldryn_jobs.cms_wizards import CreateJobOpeningForm
-
 from .base import JobsBaseTestCase
 
 if sys.version_info < (2, 7):
@@ -29,6 +27,9 @@ class TestJobsWizard(JobsBaseTestCase):
         )
 
     def test_job_opening_wizard(self):
+        # Import here to avoid logic wizard machinery
+        from aldryn_jobs.cms_wizards import CreateJobOpeningForm
+
         data = {
             'title': 'Ninja coder',
             'lead_in': 'Ninja coder wanted',

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,7 @@ commands =
     fe: sleep 60
     fe: gulp tests:integration
 deps =
+    py26: unittest2
     dj16: -rtest_requirements/django_1.6.txt
     dj17: -rtest_requirements/django_1.7.txt
     dj18: -rtest_requirements/django_1.8.txt


### PR DESCRIPTION
* Fixes ``KeyError`` when adding Job opening through wizard in 3.3
* Adds simple job wizard test.