### PR TITLE
Fixed categories and openings not being sortable

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+1.2.1 (Unreleased)
+------------------
+
+* Fixed categories and openings not being sortable
+
 
 1.2.0 (2016-05-26)
 ------------------

--- a/aldryn_jobs/admin.py
+++ b/aldryn_jobs/admin.py
@@ -146,6 +146,7 @@ class JobCategoryAdmin(VersionedPlaceholderAdminMixin,
     form = JobCategoryAdminForm
     list_display = ['__str__', 'app_config']
     filter_horizontal = ['supervisors']
+    change_list_template = 'admin/aldryn_jobs/change_list.html'
 
     def get_fieldsets(self, request, obj=None):
         fieldsets = [
@@ -180,6 +181,7 @@ class JobOpeningAdmin(VersionedPlaceholderAdminMixin,
     list_display = ['__str__', 'category', 'num_applications', ]
     frontend_editable_fields = ('title', 'lead_in')
     inlines = [JobApplicationInline, ]
+    change_list_template = 'admin/aldryn_jobs/change_list.html'
 
     def get_fieldsets(self, request, obj=None):
         fieldsets = [

--- a/aldryn_jobs/templates/admin/aldryn_jobs/change_list.html
+++ b/aldryn_jobs/templates/admin/aldryn_jobs/change_list.html
@@ -1,0 +1,10 @@
+{% extends "adminsortable2/change_list.html" %}
+{% load i18n %}
+
+{# copy of django-reversion changelist https://github.com/etianen/django-reversion/blob/master/reversion/templates/reversion/change_list.html #}
+{% block object-tools-items %}
+    {% if not is_popup %}
+        <li><a href="{{recoverlist_url}}" class="recoverlink">{% blocktrans with cl.opts.verbose_name_plural|escape as name %}Recover deleted {{name}}{% endblocktrans %}</a></li>
+    {% endif %}
+    {{block.super}}
+{% endblock %}


### PR DESCRIPTION
Since adminsortable2 and django-reversion both extend admin/change_list it wasn't possible to extend from both of them
at the same time. This commit adds our own template that has reversion modifications in it and extends adminsortable one
instead.

Thanks to @czpython for the solution